### PR TITLE
Feature/custom href pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,20 @@ bower install markdown-it-link-attributes --save
 var md = require('markdown-it')()
 var mila = require('markdown-it-link-attributes')
 
-// Config
 const options = {
-  pattern: RegExp, // Default: undefined
-  ignoreRelative: Boolean, // Default: false
-  ...attrs // Attributes to assign to the link
+  pattern: RegExp, // Default: undefined; Allow to all links
+  ...attrs // Attributes to assign to the links
 }
 
 md.use(mila, options)
-// or
-md.use(mila, [ ...options ])
+md.use(mila, [ ...options ]) // If you have several rules to apply
 ```
 
 ```js
 md.use(mila, {
+  pattern: /^https?:/,
   target: '_blank',
   rel: 'noopener',
-  ignoreRelative: true // Prevent open relative links in a new window
 })
 
 var html = md.render('[link](https://google.com)')
@@ -43,36 +40,31 @@ html = md.render('[Go Top](#top)')
 html // <p><a href="#top">link</a></p>
 ```
 
-You can also assign different attributes to specified href by pattern.
+You can also apply different attributes belongs to href pattern.
 
 ```js
 md.use(mila, [{
-  pattern: /^\/about/,
-  rel: 'author'
-}, {
-  ignoreRelative: true,
+  pattern: /^https?:/,
   target: '_blank',
   rel: 'noopener'
 }, {
-  'data-is-internal': true
+  pattern: /^\/about\/\w+/
+  rel: 'author'
+}, {
+  'data-is-other': true
 }])
-
-// The first one only catches hrefs which starts with `/about`
-// The second one catches absolute links which uncatched from previous
-// The last one catches all lefts links
-
-md.render('[About me](/about/steve)')
-// <p><a href="/about/steve" rel="author">About me</a></p>
 
 md.render('[Can I Use ?](https://caniuse.com/)')
 // <p><a href="https://caniuse.com/" target="_blank" rel="noopener">Can I Use ?</a></p>
 
+md.render('[About me](/about/steve)')
+// <p><a href="/about/steve" rel="author">About me</a></p>
+
 md.render('[Reference](#reference)')
-// <p><a href="#reference" data-is-internal="true">Reference</a></p>
+// <p><a href="#reference" data-is-other="true">Reference</a></p>
 
 md.render('[Submit](?page=docs)')
-// <p><a href="?page=docs" data-is-internal="true">Submit</a></p>
-
+// <p><a href="?page=docs" data-is-other="true">Submit</a></p>
 ```
 
 If the `linkify` option is set to `true` on `markdown-it`, then the attributes will be applied to plain links as well.

--- a/README.md
+++ b/README.md
@@ -16,16 +16,63 @@ bower install markdown-it-link-attributes --save
 ```js
 var md = require('markdown-it')()
 var mila = require('markdown-it-link-attributes')
+
+// Config
+const options = {
+  pattern: RegExp, // Default: undefined
+  ignoreRelative: Boolean, // Default: false
+  ...attrs // Attributes to assign to the link
+}
+
+md.use(mila, options)
+// or
+md.use(mila, [ ...options ])
 ```
 
 ```js
 md.use(mila, {
   target: '_blank',
-  rel: 'noopener'
+  rel: 'noopener',
+  ignoreRelative: true // Prevent open relative links in a new window
 })
 
 var html = md.render('[link](https://google.com)')
 html // <p><a href="https://google.com" target="_blank" rel="noopener">link</a></p>
+
+html = md.render('[Go Top](#top)')
+html // <p><a href="#top">link</a></p>
+```
+
+You can also assign different attributes to specified href by pattern.
+
+```js
+md.use(mila, [{
+  pattern: /^\/about/,
+  rel: 'author'
+}, {
+  ignoreRelative: true,
+  target: '_blank',
+  rel: 'noopener'
+}, {
+  'data-is-internal': true
+}])
+
+// The first one only catches hrefs which starts with `/about`
+// The second one catches absolute links which uncatched from previous
+// The last one catches all lefts links
+
+md.render('[About me](/about/steve)')
+// <p><a href="/about/steve" rel="author">About me</a></p>
+
+md.render('[Can I Use ?](https://caniuse.com/)')
+// <p><a href="https://caniuse.com/" target="_blank" rel="noopener">Can I Use ?</a></p>
+
+md.render('[Reference](#reference)')
+// <p><a href="#reference" data-is-internal="true">Reference</a></p>
+
+md.render('[Submit](?page=docs)')
+// <p><a href="?page=docs" data-is-internal="true">Submit</a></p>
+
 ```
 
 If the `linkify` option is set to `true` on `markdown-it`, then the attributes will be applied to plain links as well.

--- a/index.js
+++ b/index.js
@@ -2,23 +2,53 @@
 
 // Adapted from https://github.com/markdown-it/markdown-it/blob/fbc6b0fed563ba7c00557ab638fd19752f8e759d/docs/architecture.md
 
-function markdownitLinkAttributes (md, config) {
-  config = config || {}
+var optionKeys = ['ignoreRelative', 'pattern']
+var absoluteUrlPattern = /^([a-z]+:)?\/\//
 
-  var defaultRender = md.renderer.rules.link_open || this.defaultRender
-  var attributes = Object.keys(config)
+function markdownitLinkAttributes (md, _config) {
+  // For downward-compatibility, pass in flat options
+  var configs = (Array.isArray(_config) ? _config : [_config || {}]).map(function (config) {
+    var result = { attrs: {} }
 
-  md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
-    attributes.forEach(function (attr) {
-      var value = config[attr]
-      var aIndex = tokens[idx].attrIndex(attr)
-
-      if (aIndex < 0) { // attr doesn't exist, add new attribute
-        tokens[idx].attrPush([attr, value])
-      } else { // attr already exists, overwrite it
-        tokens[idx].attrs[aIndex][1] = value // replace value of existing attr
+    Object.keys(config).forEach(function (key) {
+      if (optionKeys.indexOf(key) > -1) {
+        result[key] = config[key]
+      } else {
+        result.attrs[key] = config[key]
       }
     })
+    return result
+  })
+
+  Object.freeze(configs)
+
+  var defaultRender = md.renderer.rules.link_open || this.defaultRender
+
+  md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+    var href = tokens[idx].attrGet('href')
+
+    var config = configs.find(function (conf) {
+      if (conf.pattern) {
+        return conf.pattern.test(href) // match custom pattern
+      } else if (conf.ignoreRelative) {
+        return absoluteUrlPattern.test(href)
+      } else {
+        return true
+      }
+    })
+
+    if (config) {
+      Object.keys(config.attrs).forEach(function (attr) {
+        var value = config.attrs[attr]
+        var aIndex = tokens[idx].attrIndex(attr)
+
+        if (aIndex < 0) { // attr doesn't exist, add new attribute
+          tokens[idx].attrPush([attr, value])
+        } else { // attr already exists, overwrite it
+          tokens[idx].attrs[aIndex][1] = value // replace value of existing attr
+        }
+      })
+    }
 
     // pass token to default renderer.
     return defaultRender(tokens, idx, options, env, self)

--- a/index.js
+++ b/index.js
@@ -2,21 +2,22 @@
 
 // Adapted from https://github.com/markdown-it/markdown-it/blob/fbc6b0fed563ba7c00557ab638fd19752f8e759d/docs/architecture.md
 
-var optionKeys = ['ignoreRelative', 'pattern']
-var absoluteUrlPattern = /^([a-z]+:)?\/\//
+var OPTION_KEYS = ['pattern']
 
 function markdownitLinkAttributes (md, _config) {
-  // For downward-compatibility, pass in flat options
-  var configs = (Array.isArray(_config) ? _config : [_config || {}]).map(function (config) {
+  var configs = Array.isArray(_config) ? _config : [_config || {}]
+
+  configs = configs.map(function (config) {
     var result = { attrs: {} }
 
     Object.keys(config).forEach(function (key) {
-      if (optionKeys.indexOf(key) > -1) {
+      if (OPTION_KEYS.indexOf(key) > -1) {
         result[key] = config[key]
       } else {
         result.attrs[key] = config[key]
       }
     })
+
     return result
   })
 
@@ -26,16 +27,15 @@ function markdownitLinkAttributes (md, _config) {
 
   md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
     var href = tokens[idx].attrGet('href')
+    var config = null
 
-    var config = configs.find(function (conf) {
-      if (conf.pattern) {
-        return conf.pattern.test(href) // match custom pattern
-      } else if (conf.ignoreRelative) {
-        return absoluteUrlPattern.test(href)
-      } else {
-        return true
+    for (var i = 0; i < configs.length; ++i) {
+      var conf = configs[i]
+      if (!conf.pattern || (conf.pattern && conf.pattern.test(href))) {
+        config = conf
+        break
       }
-    })
+    }
 
     if (config) {
       Object.keys(config.attrs).forEach(function (attr) {

--- a/test/index.js
+++ b/test/index.js
@@ -33,31 +33,39 @@ describe('markdown-it-link-attributes', function () {
     expect(result).to.contain('<a href="https://google.com" target="_blank" rel="noopener" foo="bar">link</a>')
   })
 
-  it('allows different rules on specific href', function () {
-    this.md.use(linkAttributes, [{
-      pattern: /\bgoogle.com\b/, // External href in http(s) protocol
+  it('takes pattern option and only apply attrs if pattern matched', function () {
+    this.md.use(linkAttributes, {
+      pattern: /^https?:\/\//,
       target: '_blank',
       rel: 'noopener'
-    }, {
-      ignoreRelative: true, // Catch other absolute hrefs
-      rel: 'noreferrer'
-    }])
+    })
 
-    // Rules to specific website
     var result = this.md.render('[link](https://google.com)')
     expect(result).to.contain('<a href="https://google.com" target="_blank" rel="noopener">link</a>')
 
-    // Other website
-    result = this.md.render('[link](https://github.com/crookedneighbor/markdown-it-link-attributes)')
-    expect(result).to.contain('<a href="https://github.com/crookedneighbor/markdown-it-link-attributes" rel="noreferrer">link</a>')
+    result = this.md.render('[link](#anchor)')
+    expect(result).to.contain('<a href="#anchor">link</a>')
+  })
 
-    // Relative page
-    result = this.md.render('[link](/page/relative-to-website)')
-    expect(result).to.contain('<a href="/page/relative-to-website">link</a>')
+  it('allows multiple rules', function () {
+    this.md.use(linkAttributes, [{
+      pattern: /^https:/,
+      class: 'has-text-uppercase'
+    }, {
+      pattern: /^#/,
+      class: 'is-blue'
+    }, {
+      class: 'is-red'
+    }])
 
-    // Anchors should work, too
-    result = this.md.render('[link](#anchor_link)')
-    expect(result).to.contain('<a href="#anchor_link">link</a>')
+    var result = this.md.render('[Google](https://www.google.com)')
+    expect(result).to.contain('<a href="https://www.google.com" class="has-text-uppercase">Google</a>')
+
+    result = this.md.render('[Go top](#top)')
+    expect(result).to.contain('<a href="#top" class="is-blue">Go top</a>')
+
+    result = this.md.render('[About](/page/about)')
+    expect(result).to.contain('<a href="/page/about" class="is-red">About</a>')
   })
 
   it('retains the original attr of a previous plugin that alters the attrs', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -33,6 +33,33 @@ describe('markdown-it-link-attributes', function () {
     expect(result).to.contain('<a href="https://google.com" target="_blank" rel="noopener" foo="bar">link</a>')
   })
 
+  it('allows different rules on specific href', function () {
+    this.md.use(linkAttributes, [{
+      pattern: /\bgoogle.com\b/, // External href in http(s) protocol
+      target: '_blank',
+      rel: 'noopener'
+    }, {
+      ignoreRelative: true, // Catch other absolute hrefs
+      rel: 'noreferrer'
+    }])
+
+    // Rules to specific website
+    var result = this.md.render('[link](https://google.com)')
+    expect(result).to.contain('<a href="https://google.com" target="_blank" rel="noopener">link</a>')
+
+    // Other website
+    result = this.md.render('[link](https://github.com/crookedneighbor/markdown-it-link-attributes)')
+    expect(result).to.contain('<a href="https://github.com/crookedneighbor/markdown-it-link-attributes" rel="noreferrer">link</a>')
+
+    // Relative page
+    result = this.md.render('[link](/page/relative-to-website)')
+    expect(result).to.contain('<a href="/page/relative-to-website">link</a>')
+
+    // Anchors should work, too
+    result = this.md.render('[link](#anchor_link)')
+    expect(result).to.contain('<a href="#anchor_link">link</a>')
+  })
+
   it('retains the original attr of a previous plugin that alters the attrs', function () {
     this.md.use(linkAttributes, {
       keep: 'keep',


### PR DESCRIPTION
I implemented a custom href pattern feature, you can checkout the new [README.md](https://github.com/shirohana/markdown-it-link-attributes/blob/feature/custom-href-pattern/README.md) and decide whether to merge (๑ơ ω ơ)

The default behavior didn't change, only new options and syntax added; fully downward-compatible. 

Feel free to tell me if anything you do not satisfied.