### PR TITLE
Upgrade dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "browserify": "^14.4.0",
     "chai": "^4.1.2",
     "chalk": "^2.1.0",
-    "markdown-it": "^8.4.0",
     "mocha": "^3.0.2",
     "rimraf": "^2.5.2",
     "sinon": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -25,16 +25,17 @@
   },
   "homepage": "https://github.com/crookedneighbor/markdown-it-link-attributes",
   "devDependencies": {
-    "browserify": "^13.0.0",
-    "chai": "^3.5.0",
-    "chalk": "^1.1.3",
+    "browserify": "^14.4.0",
+    "chai": "^4.1.2",
+    "chalk": "^2.1.0",
+    "markdown-it": "^8.4.0",
     "mocha": "^3.0.2",
     "rimraf": "^2.5.2",
-    "sinon": "^1.17.3",
+    "sinon": "^3.2.1",
     "sinon-chai": "^2.8.0",
-    "snazzy": "^6.0.0",
-    "standard": "^8.1.0",
-    "uglify-js": "^2.6.2"
+    "snazzy": "^7.0.0",
+    "standard": "^10.0.3",
+    "uglify-js": "^3.1.0"
   },
   "standard": {
     "globals": [

--- a/test/index.js
+++ b/test/index.js
@@ -70,6 +70,7 @@ describe('markdown-it-link-attributes', function () {
 
     this.md.render('[link](https://google.com)')
 
+    // eslint-disable-next-line no-unused-expressions
     expect(spy).to.be.calledOnce
   })
 
@@ -79,6 +80,7 @@ describe('markdown-it-link-attributes', function () {
 
     this.md.render('[link](https://google.com)')
 
+    // eslint-disable-next-line no-unused-expressions
     expect(spy).to.be.calledOnce
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -70,8 +70,7 @@ describe('markdown-it-link-attributes', function () {
 
     this.md.render('[link](https://google.com)')
 
-    // eslint-disable-next-line no-unused-expressions
-    expect(spy).to.be.calledOnce
+    expect(spy).to.be.calledOnce // eslint-disable-line no-unused-expressions
   })
 
   it('calls default render if link_open rule is not defined', function () {
@@ -80,7 +79,6 @@ describe('markdown-it-link-attributes', function () {
 
     this.md.render('[link](https://google.com)')
 
-    // eslint-disable-next-line no-unused-expressions
-    expect(spy).to.be.calledOnce
+    expect(spy).to.be.calledOnce // eslint-disable-line no-unused-expressions
   })
 })


### PR DESCRIPTION
It seems nothing has to been changed except the fixes of https://github.com/crookedneighbor/markdown-it-link-attributes/pull/15.

`test && build && minify` all passed.