### PR TITLE
Remove dist from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 test
-dist
 tasks
 examples
 bower.json

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ result // <a href="https://example.com/blue" class="external-link">external</a>
 ## Usage in the browser
 
 _Differences in browser._ If you load script directly into the page, without a package system, the module will add itself globally as `window.markdownitLinkAttributes`.
+You need to load `dist/markdown-it-link-attributes.min.js`, if you don't use a build system. 
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "minify": "uglifyjs dist/markdown-it-link-attributes.js > dist/markdown-it-link-attributes.min.js",
     "lint": "standard | snazzy",
     "pretest": "npm run lint && npm run build",
-    "test": "mocha"
+    "test": "mocha",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove dist folder from npmignore. This allows package users to import minified version of code and use non CommonJS import systems. This fixes #20 

Also, change package.json.main to point to the minified version of code. This is to load minified version instead of `index.js`, when folks use this code:

```javascript
import mila from 'markdown-it-link-attributes'
```

Not sure if it should be a breaking change. I think it's not.